### PR TITLE
fix: add build step to GitHub workflow before semantic-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Build
+        run: npm run build
+
       - name: Test
         run: npm run test
 


### PR DESCRIPTION
Ensures the dist directory is generated before the package is published to npm. This fixes the issue where the package was published without the compiled distribution files needed for consumers to use the library.