### PR TITLE
fix: ensure dist directory is included in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "node -r dotenv/config ./dist/example/index.js dotenv_config_path=./example/.dev.vars",
     "build": "tsc",
-    "test": "echo \"No tests specified - skipping tests\" && true"
+    "test": "echo \"No tests specified, skipping tests\" && true"
   },
   "main": "./dist/src/index.js",
   "keywords": [


### PR DESCRIPTION
This ensures the library can be properly consumed by users. Previous package was missing the compiled distribution files.