### PR TITLE
fix: configure release branches for semantic-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,5 +5,6 @@
     "@semantic-release/changelog",
     "@semantic-release/npm",
     "@semantic-release/git"
-  ]
+  ],
+  "branches": ["main"]
 }


### PR DESCRIPTION
- Adds "branches": ["main"] configuration to semantic-release
- Fixes ERELEASEBRANCHES error in GitHub workflow
- Ensures releases only run from the main branch